### PR TITLE
Support configurable field names

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,31 @@ PATH
   remote: .
   specs:
     stateful_model_rails (0.1.0)
+      activerecord (>= 5.0.0)
+      activesupport (>= 5.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (7.0.2.3)
+      activesupport (= 7.0.2.3)
+    activerecord (7.0.2.3)
+      activemodel (= 7.0.2.3)
+      activesupport (= 7.0.2.3)
+    activesupport (7.0.2.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     ast (2.4.2)
     byebug (11.1.3)
     coderay (1.1.3)
+    concurrent-ruby (1.1.10)
     diff-lcs (1.4.4)
+    i18n (1.10.0)
+      concurrent-ruby (~> 1.0)
     method_source (1.0.0)
+    minitest (5.15.0)
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -55,12 +71,16 @@ GEM
       pry (~> 0.13.0)
       tty-screen (~> 0.8.1)
     tty-screen (0.8.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord (>= 5.0.0)
+  activesupport (>= 5.0.0)
   rake (~> 12.0)
   rspec (~> 3.0)
   rubocop (~> 1.22)

--- a/lib/stateful_model_rails.rb
+++ b/lib/stateful_model_rails.rb
@@ -4,6 +4,8 @@ require "stateful_model_rails/version"
 require "stateful_model_rails/state_machine"
 require "stateful_model_rails/transition"
 
+require "active_support/core_ext/string/inflections"
+
 module StatefulModelRails
   class Error < StandardError; end
 

--- a/lib/stateful_model_rails/state_machine.rb
+++ b/lib/stateful_model_rails/state_machine.rb
@@ -118,8 +118,8 @@ module StatefulModelRails::StateMachine
   end
 end
 
-def included__state_machine(opts, &block)
-  field_name = opts.fetch(:on, "state")
+def included__state_machine(opts = {}, &block)
+  field_name = opts.fetch(:on, "state").to_s
 
   @state_machine = StatefulModelRails::StateMachine::StateMachineInternal.new(field_name)
   @state_machine.instance_eval(&block)

--- a/lib/stateful_model_rails/state_machine.rb
+++ b/lib/stateful_model_rails/state_machine.rb
@@ -52,7 +52,7 @@ module StatefulModelRails::StateMachine
   end
 
   class StateMachineInternal
-    attr_reader :seen_states, :transition_map
+    attr_reader :seen_states, :transition_map, :field_name
 
     def initialize(field_name)
       @field_name = field_name
@@ -129,11 +129,13 @@ end
 
 def included__state
   sm_instance = self.class.state_machine_instance
+  field_name = sm_instance.field_name
+
   st = sm_instance.seen_states.detect do |sf|
-    sf.name == attributes["state"]
+    sf.name == attributes[field_name]
   end
 
-  raise StatefulModelRails::MissingStateDefinition, attributes["state"] if st.nil?
+  raise StatefulModelRails::MissingStateDefinition, attributes[field_name] if st.nil?
 
   st
 end

--- a/lib/stateful_model_rails/state_machine.rb
+++ b/lib/stateful_model_rails/state_machine.rb
@@ -132,7 +132,7 @@ def included__state
   field_name = sm_instance.field_name
 
   st = sm_instance.seen_states.detect do |sf|
-    sf.name == attributes[field_name]
+    sf.name.underscore == attributes[field_name].underscore
   end
 
   raise StatefulModelRails::MissingStateDefinition, attributes[field_name] if st.nil?

--- a/spec/stateful_model_rails/state_derivation_spec.rb
+++ b/spec/stateful_model_rails/state_derivation_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe StatefulModelRails::StateMachine do
 
         expect(instance.state).to eq(StateA)
       end
+
+      it "is case-insensitive" do
+        instance = effective_class.new
+        allow(instance).to receive(:attributes).and_return({ "state" => "state_a" })
+
+        expect(instance.state).to eq(StateA)
+      end
     end
 
     context "when configuring the `on` field" do

--- a/spec/stateful_model_rails/state_derivation_spec.rb
+++ b/spec/stateful_model_rails/state_derivation_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "stateful_model_rails"
+
+RSpec.describe StatefulModelRails::StateMachine do
+  describe "state derivation" do
+    context "without configuring the `on` field" do
+      def effective_class
+        Class.new do
+          include StatefulModelRails::StateMachine
+
+          state_machine do
+            transition :void, from: StateA, to: StateA
+          end
+        end
+      end
+
+      let(:instance) { effective_class.new }
+
+      it "derives from `state`" do
+        instance = effective_class.new
+        allow(instance).to receive(:attributes).and_return({ "state" => "StateA" })
+
+        expect(instance.state).to eq(StateA)
+      end
+    end
+  end
+end

--- a/spec/stateful_model_rails/state_derivation_spec.rb
+++ b/spec/stateful_model_rails/state_derivation_spec.rb
@@ -24,5 +24,26 @@ RSpec.describe StatefulModelRails::StateMachine do
         expect(instance.state).to eq(StateA)
       end
     end
+
+    context "when configuring the `on` field" do
+      def effective_class
+        Class.new do
+          include StatefulModelRails::StateMachine
+
+          state_machine(on: :other_field) do
+            transition :void, from: StateA, to: StateA
+          end
+        end
+      end
+
+      let(:instance) { effective_class.new }
+
+      it "derives from the declared field" do
+        instance = effective_class.new
+        allow(instance).to receive(:attributes).and_return({ "other_field" => "StateA" })
+
+        expect(instance.state).to eq(StateA)
+      end
+    end
   end
 end

--- a/stateful_model_rails.gemspec
+++ b/stateful_model_rails.gemspec
@@ -19,6 +19,9 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/bagedevimo/stateful-model-rails"
   spec.metadata["changelog_uri"] = "https://github.com/bagedevimo/stateful-model-rails"
 
+  spec.add_runtime_dependency "activerecord", ">= 5.0.0"
+  spec.add_runtime_dependency "activesupport", ">= 5.0.0"
+
   spec.files = Dir["lib/**/*"]
   spec.bindir        = "bin"
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
This looks to have been _intended_, but didn't actually work. While we're here, we allow for a slightly more flexible class name matcher.