### PR TITLE
Add support for multisource transitions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     stateful_model_rails (0.1.0)
-      activerecord (>= 5.0.0)
-      activesupport (>= 5.0.0)
+      activerecord (>= 5.2.0)
+      activesupport (>= 5.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -79,8 +79,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (>= 5.0.0)
-  activesupport (>= 5.0.0)
   rake (~> 12.0)
   rspec (~> 3.0)
   rubocop (~> 1.22)

--- a/lib/stateful_model_rails/state_machine.rb
+++ b/lib/stateful_model_rails/state_machine.rb
@@ -62,9 +62,12 @@ module StatefulModelRails::StateMachine
 
     def transition(event, from:, to:)
       @transition_map[event] ||= []
-      @transition_map[event] << StatefulModelRails::Transition.new(from, to)
+      Array(from).each do |from|
+        @transition_map[event] << StatefulModelRails::Transition.new(from, to)
 
-      @seen_states << from
+        @seen_states << from
+      end
+
       @seen_states << to
       @seen_states.uniq!
     end

--- a/spec/stateful_model_rails/errors_spec.rb
+++ b/spec/stateful_model_rails/errors_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe StatefulModelRails::StateMachine do
         @state = state
       end
 
+      def with_lock
+        yield if block_given?
+      end
+
       def attributes
         { "state" => @state }
       end

--- a/spec/stateful_model_rails/graph_construction_spec.rb
+++ b/spec/stateful_model_rails/graph_construction_spec.rb
@@ -83,6 +83,25 @@ RSpec.describe StatefulModelRails::StateMachine do
       end
     end
 
+    context "with one multi-source transition" do
+      let(:table) do
+        proc do
+          transition :example1, from: [StateA, StateB], to: StateC
+        end
+      end
+
+      it "returns a transition table that expands the sources" do
+        expect(graph.keys).to match_array([:example1])
+
+        expect(graph[:example1]).to match_array(
+          [
+            StatefulModelRails::Transition.new(StateA, StateC),
+            StatefulModelRails::Transition.new(StateB, StateC)
+          ]
+        )
+      end
+    end
+
     context "with two transitions, same events different states, looped" do
       let(:table) do
         proc do

--- a/spec/stateful_model_rails/hooks_spec.rb
+++ b/spec/stateful_model_rails/hooks_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe StatefulModelRails::StateMachine do
         @state = state
       end
 
+      def with_lock
+        yield if block_given?
+      end
+
       def attributes
         { "state" => @state }
       end

--- a/spec/stateful_model_rails/transition_execution_spec.rb
+++ b/spec/stateful_model_rails/transition_execution_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe StatefulModelRails::StateMachine do
         @state = state
       end
 
+      def with_lock
+        yield if block_given?
+      end
+
       def attributes
         { "state" => @state }
       end
@@ -65,6 +69,10 @@ RSpec.describe StatefulModelRails::StateMachine do
 
         def update!(field_name:)
           @field_name = field_name
+        end
+
+        def with_lock
+          yield if block_given?
         end
 
         def attributes


### PR DESCRIPTION
This lets us condense

```ruby
transition :event, from: A, to: F
transition :event, from: C, to: F
transition :event, from: B, to: F
```

to 
```ruby
transition :event, from: [A,B,C], to: F
```

which is occasionally convenient shorthand.